### PR TITLE
Investigate vercel not found error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,9 @@
 {
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/" }
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }
 


### PR DESCRIPTION
Configure `vercel.json` for Vite SPA to resolve 'CODE: NOT_FOUND' errors by adding a rewrite to `index.html` and setting build parameters.

The "CODE: NOT_FOUND" error on Vercel for this Vite SPA was due to the server not correctly serving `index.html` for client-side routes. This change ensures all requests are routed to the SPA entry point and Vercel correctly identifies the Vite project setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-5228abf6-a655-44a9-bde9-5bc964c5b3d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5228abf6-a655-44a9-bde9-5bc964c5b3d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

